### PR TITLE
Updated index page cards to improve spacing and stack for mobile

### DIFF
--- a/bam_pow/src/components/AuthorIndex.js
+++ b/bam_pow/src/components/AuthorIndex.js
@@ -99,7 +99,13 @@ const AuthorIndex = ({ user, msgAlert }) => {
       </Link>
       <h1 className="index-header">Authors</h1>
       <Container className="comic-panel">
-        <Card.Group centered >{AuthorCards}</Card.Group>
+        <Card.Group 
+          centered
+          stackable
+          itemsPerRow={5} 
+          >
+            {AuthorCards}
+        </Card.Group>
       </Container>
     </>
   );

--- a/bam_pow/src/components/CharacterIndex.js
+++ b/bam_pow/src/components/CharacterIndex.js
@@ -97,7 +97,13 @@ const CharacterIndex = ({ user, msgAlert }) => {
 			</Link>
 			<h1 className="index-header">Characters</h1>
 			<Container className="comic-panel" >
-				<Card.Group centered >{CharacterCards}</Card.Group>
+			<Card.Group 
+				centered
+				stackable
+				itemsPerRow={3} 
+				>
+					{CharacterCards}
+				</Card.Group>
 			</Container>
 		</>
 	)

--- a/bam_pow/src/components/ComicIndex.js
+++ b/bam_pow/src/components/ComicIndex.js
@@ -83,7 +83,13 @@ const ComicIndex = ({ user, msgAlert }) => {
 			</Link>
 			<h1 className="index-header">All Comics</h1>
 			<Container className="comic-panel">
-				<Card.Group centered>{ComicCards}</Card.Group>
+				<Card.Group 
+					centered 
+					stackable
+					itemsPerRow={4}
+					>
+						{ComicCards}
+				</Card.Group>
 			</Container>
 		</>
 	)

--- a/bam_pow/src/components/IllustratorIndex.js
+++ b/bam_pow/src/components/IllustratorIndex.js
@@ -90,7 +90,13 @@ const IllustratorIndex = ({ user, msgAlert }) => {
       </Link>
       <h1 className="index-header">Illustrators</h1>
       <Container className="comic-panel">
-        <Card.Group >{IllustratorCards}</Card.Group>
+        <Card.Group 
+            centered
+            stackable
+            itemsPerRow={5} 
+            >
+              {IllustratorCards}
+          </Card.Group>
       </Container>
     </>
   );

--- a/bam_pow/src/components/PublisherIndex.js
+++ b/bam_pow/src/components/PublisherIndex.js
@@ -87,7 +87,13 @@ const PublisherIndex = ({ user, msgAlert }) => {
       </Link>
       <h1 className="index-header">Publishers</h1>
       <Container className="comic-panel">
-        <Card.Group centered>{PublisherCards}</Card.Group>
+        <Card.Group 
+            centered
+            stackable
+            itemsPerRow={4} 
+            >
+              {PublisherCards}
+          </Card.Group>
       </Container>
     </>
   );


### PR DESCRIPTION
Added "stackable" and itemsPerRow={<#>} parameters to Card.Group tags to specify the number of cards per row but to also allow mobile viewers to view all the cards stacked